### PR TITLE
allow for deserializer to return encoded images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "6.4.5",
+  "version": "6.4.6",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -3,7 +3,7 @@ import set from 'lodash/set'
 import sortBy from 'lodash/sortBy'
 import toPairs from 'lodash/toPairs'
 
-const deserializeDocument = ({ data, ...metadata }, options = { react: true }) => {
+const deserializeDocument = ({ data, ...metadata }, options = { react: true, encodeImage: false }) => {
   const deserializedFields = deserializeFields(data, options)
 
   return {
@@ -43,7 +43,7 @@ const deserializeField = (value, options) => {
   } else if (isImage(value)) {
     return {
       ...value,
-      url: value.url.replace('auto=compress,format', '')
+      url: !options.encodeImage ? value.url.replace('auto=compress,format', '') : value.url
     }
   } else {
     return value


### PR DESCRIPTION
Would like the ability to allow Prismic compression on images as these will also serve next-gen image formats that can help with page speed. DUK sites currently use older version of prismic-utils that is using Prismic's compression and they are generally happy with the results.